### PR TITLE
Introduce static .extract function for usage outside controllers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
   - rubocop-performance
   - rubocop-rails
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 119 # line length on GitHub's PR pages
 
 Metrics/MethodLength:

--- a/README.md
+++ b/README.md
@@ -118,3 +118,18 @@ class API::ResourcesController < API::ApplicationController
   authorize_by_jwt_scopes 'resources', unless: -> { params[:skip] == '1' }
 end
 ```
+
+### Usage outside a Rails controller
+
+If you need to access a JWT outside the normal Rails controllers (e.g. in a Rack
+middleware), there's a static helper method `.extract` which you can use:
+
+```ruby
+class MyRackMiddleware < Rack::Middleware
+  def call(env)
+    token = Zaikio::JWTAuth.extract(env["HTTP_AUTHORIZATION"])
+    puts token.subject_type #=> "Organization"
+    ...
+```
+
+This function expects to receive the string in the format `"Bearer $token"`.

--- a/lib/zaikio/jwt_auth/configuration.rb
+++ b/lib/zaikio/jwt_auth/configuration.rb
@@ -18,6 +18,7 @@ module Zaikio
       def initialize
         @environment = :sandbox
         @revoked_token_ids = nil
+        @keys = nil
       end
 
       def logger
@@ -30,7 +31,7 @@ module Zaikio
       end
 
       def keys
-        defined?(@keys) && @keys.is_a?(Proc) ? @keys.call : @keys
+        @keys.is_a?(Proc) ? @keys.call : @keys
       end
 
       def revoked_token_ids

--- a/test/zaikio/jwt_auth_test.rb
+++ b/test/zaikio/jwt_auth_test.rb
@@ -125,6 +125,12 @@ class ResourcesControllerTest < ActionDispatch::IntegrationTest # rubocop:disabl
     assert_equal({ "errors" => ["no_jwt_passed"] }.to_json, response.body)
   end
 
+  test "unauthorized if not prefixed with `Bearer `" do
+    get "/resources", headers: { "Authorization" => generate_token }
+    assert_response :unauthorized
+    assert_equal({ "errors" => ["no_jwt_passed"] }.to_json, response.body)
+  end
+
   test "forbidden if invalid JWT was passed" do
     get "/resources", headers: { "Authorization" => "Bearer xxx" }
     assert_response :forbidden


### PR DESCRIPTION
This is particularly helpful for use in Rack middleware, for example.

Note that two private internal methods have been removed, `jwt_from_auth_header` and `jwt_payload`. I couldn't find any references to these so I assume they are safe to remove!