### PR TITLE
Only lookup Webhooks module under Zaikio:: namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [0.4.3] - 2020-03-17
+
+* Fix incorrect const_defined? behaviour when initializing without zaikio-webhooks gem
+
 ### [0.4.2] - 2020-02-18
 * Add authorization for custom actions and scope types
 
@@ -15,5 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add a changelog
 * Setup automated gem publishing
 
-[Unreleased]: https://github.com/zaikio/zaikio-directory-models/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/zaikio/zaikio-directory-models/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/zaikio/zaikio-directory-models/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/zaikio/zaikio-directory-models/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/zaikio/zaikio-directory-models/compare/d601d8c2f5c68f9c440755a8fbf9e17b4ae79a66...v0.4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-jwt_auth (0.4.2)
+    zaikio-jwt_auth (0.4.3)
       jwt (>= 2.2.1)
       oj (>= 3.0.0)
       rails (>= 5.0.0)

--- a/lib/zaikio/jwt_auth.rb
+++ b/lib/zaikio/jwt_auth.rb
@@ -18,7 +18,7 @@ module Zaikio
     def self.configure
       self.configuration ||= Configuration.new
 
-      if Zaikio.const_defined?("Webhooks")
+      if Zaikio.const_defined?("Webhooks", false)
         Zaikio::Webhooks.on "directory.revoked_access_token", Zaikio::JWTAuth::RevokeAccessTokenJob,
                             perform_now: true
       end

--- a/lib/zaikio/jwt_auth/version.rb
+++ b/lib/zaikio/jwt_auth/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module JWTAuth
-    VERSION = "0.4.2".freeze
+    VERSION = "0.4.3".freeze
   end
 end


### PR DESCRIPTION
`const_defined?` takes two arguments. Given just the following code:

```ruby
  module Zaikio; end
  module Webhooks; end

  Zaikio.const_defined?("Webhooks") => true # wrong
  const_defined?("Webhooks")        => true # correct
```

We only want to find any `Webhooks` module _inside_ the Zaikio namespace, not the top-level one. We need to pass a second argument, `false`, to tell it to not recurse upwards until it finds something.

This was breaking in the Hub, where the zaikio-webhooks gem is not loaded.