### PR TITLE
Interpret HTTP 429 as a failure and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Throw a `Zaikio::JWTAuth::DirectoryCache::BadResponseError` when the server returns with
+  an unexpected HTTP 4xx error code or non-JSON body.
+
 ### [0.4.4] - 2020-03-25
 
  * Replace dependency on `rails` with a more specific dependency on `railties`

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -107,12 +107,12 @@ i15NDU2sOtIV5ZgaraNIP8o8+KybAdj15shKrsm3nFTJMLScg1KLOA==
 
   def stub_requests
     stub_request(:get, "http://hub.zaikio.test/api/v1/jwt_public_keys.json")
-      .to_return(status: 200, body: {
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: {
         keys: [JWT::JWK::RSA.new(dummy_private_key.public_key).export]
       }.to_json)
 
     stub_request(:get, "http://hub.zaikio.test/api/v1/revoked_access_tokens.json")
-      .to_return(status: 200, body: {
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: {
         revoked_token_ids: %w[bad-token very-bad-token]
       }.to_json)
   end

--- a/test/zaikio/directory_cache_test.rb
+++ b/test/zaikio/directory_cache_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class Zaikio::JWTAuth::DirectoryCacheTest < ActiveSupport::TestCase
+  test "when server responds with a 429 response" do
+    stub_request(:get, "http://hub.zaikio.test/foo.json")
+      .to_return(status: 429, body: "Retry later", headers: { "Content-Type" => "text/plain" })
+
+    assert_raises(Zaikio::JWTAuth::DirectoryCache::BadResponseError) do
+      Zaikio::JWTAuth::DirectoryCache.fetch("foo.json")
+    end
+  end
+end


### PR DESCRIPTION
Fixes this error (as seen from the Hub when rate limited):

```
  Oj::ParseError
  unexpected character (after ) at line 1, column 1 [parse.c:769]
```