### PR TITLE
Make DirectoryCache fail-open with stale data and async update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* **BREAKING** When updating the `DirectoryCache` (either using `invalidate: true` or when
+  the cache expires), it will no longer retry & sleep, blocking the main thread.
+  Instead, it enqueues a background job to attempt the update (and will re-queue again, if
+  needed, until the job succeeds.
+
 ## [0.5.1] - 2021-04-21
 
 * Set correct `use_ssl` flag on `net/http` when working with HTTPS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-jwt_auth (0.5.0)
+    zaikio-jwt_auth (0.5.1)
       jwt (>= 2.2.1)
       oj (>= 3.0.0)
       railties (>= 5.0.0)

--- a/test/zaikio/directory_cache_test.rb
+++ b/test/zaikio/directory_cache_test.rb
@@ -1,19 +1,49 @@
 require "test_helper"
 
-class Zaikio::JWTAuth::DirectoryCacheTest < ActiveSupport::TestCase
-  def setup
-    Zaikio::JWTAuth.configure do |config|
-      config.environment = :test
-      config.app_name = "test_app"
+module Zaikio::JWTAuth
+  class DirectoryCacheTest < ActiveSupport::TestCase
+    def setup
+      Zaikio::JWTAuth.configure do |config|
+        config.environment = :test
+      end
     end
-  end
 
-  test "when server responds with a 429 response" do
-    stub_request(:get, "http://hub.zaikio.test/foo.json")
-      .to_return(status: 429, body: "Retry later", headers: { "Content-Type" => "text/plain" })
+    test "when server responds with a 429 response, we return existing set and enqueue job to update" do
+      # First, fill the cache with a successful response
+      stub_request(:get, "http://hub.zaikio.test/foo.json")
+        .to_return(status: 200,
+                   headers: { "Content-Type" => "application/json" }, body: {
+                     revoked_token_ids: %w[old-token]
+                   }.to_json)
+        .then.to_return(status: 429, body: "Retry later", headers: { "Content-Type" => "text/plain" })
 
-    assert_raises(Zaikio::JWTAuth::DirectoryCache::BadResponseError) do
-      assert Zaikio::JWTAuth::DirectoryCache.fetch("foo.json", invalidate: true)
+      assert_equal(
+        { "revoked_token_ids" => %w[old-token] },
+        DirectoryCache.fetch("foo.json", invalidate: true)
+      )
+
+      # Now pretend the Hub has become unavailable
+      stub_request(:get, "http://hub.zaikio.test/foo.json")
+        .to_return(status: 429, body: "Retry later", headers: { "Content-Type" => "text/plain" })
+
+      DirectoryCache::UpdateJob.expects(:set).with(wait: 10.seconds).returns(DirectoryCache::UpdateJob)
+      DirectoryCache::UpdateJob.expects(:perform_later).with("foo.json")
+
+      assert_equal(
+        { "revoked_token_ids" => %w[old-token] },
+        DirectoryCache.fetch("foo.json", invalidate: true)
+      )
+    end
+
+    test "UpdateJob runs the fetch command" do
+      stub_request(:get, "http://hub.zaikio.test/foo.json")
+        .to_return(status: 200,
+                   headers: { "Content-Type" => "application/json" }, body: {
+                     revoked_token_ids: %w[old-token]
+                   }.to_json)
+        .then.to_return(status: 429, body: "Retry later", headers: { "Content-Type" => "text/plain" })
+
+      assert DirectoryCache::UpdateJob.new.perform("foo.json")
     end
   end
 end


### PR DESCRIPTION
> Context: https://github.com/zaikio/zaikio-jwt_auth/pull/160#issuecomment-823882249

Previously, if `DirectoryCache` encountered an HTTP issue while updating, it would sleep for one second and then retry, up to three times, before raising the error to the consumer.

This has two problems:

  1. It blocks the main thread for ~3 seconds for a persistent failure
  2. The consumer needs to also rescue some of these exceptions and decide what to do with it.

This commit alters the default journey. If the `DirectoryCache` is unable to refresh itself immediately, we return stale data (or no data, if none available), log the issue, then enqueue a job to try and fetch the data in a while. This background job will then continually retry to update the `DirectoryCache` until it succeeds.

After this change, the consumer can expect the cache to be immediately updated or receive stale data, and not have to worry about catching exceptions or blocking the main thread for very long.