### PR TITLE
Copy `authorize_by_jwt_*` behaviours to child classes when inheriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* After setting `authorize_by_jwt_subject_type` and `authorize_by_jwt_scopes` in a
+  controller, any classes inheriting from your controller will also get a copy of those
+  attributes. You can override this behaviour by calling the methods again in the child
+  class.
+
 ## [1.0.1] - 2021-04-28
 
 * Bugfix: add runtime dependency `activejob` for rebuilding the `DirectoryCache`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ end
 
 By convention, `authorize_by_jwt_scopes` automatically maps all CRUD actions in a controller. Requests for `show` and `index` with a read or read_write scope are allowed. All other actions like `create`, `update` and `destroy` are accepted if the scope is a write or read_write scope. Therefore it is strongly recommended to always create standard Rails resources. If a custom action is required, you will need to authorize yourself using the `after_jwt_auth`.
 
+Both of these behaviours are automatically inherited by child classes, for example:
+
+```ruby
+class API::ChildController < API::ResourcesController
+end
+
+API::ChildController.authorize_by_jwt_subject_type
+#=> "Organization"
+```
+
+You can always override the behaviour in children if needed:
+
+```ruby
+class API::ChildController < API::ResourcesController
+  authorize_by_jwt_subject_type nil
+end
+```
+
 #### Modifying required scopes
 If you nonetheless want to change the required scopes for CRUD routes, you can use the `type` option which accepts the following values: `:read`, `:write`, `:read_write`
 

--- a/lib/zaikio/jwt_auth.rb
+++ b/lib/zaikio/jwt_auth.rb
@@ -82,6 +82,13 @@ module Zaikio
 
         @authorize_by_jwt_scopes
       end
+
+      def inherited(child)
+        super(child)
+
+        child.instance_variable_set(:@authorize_by_jwt_subject_type, @authorize_by_jwt_subject_type)
+        child.instance_variable_set(:@authorize_by_jwt_scopes, @authorize_by_jwt_scopes)
+      end
     end
 
     module InstanceMethods

--- a/lib/zaikio/jwt_auth.rb
+++ b/lib/zaikio/jwt_auth.rb
@@ -45,7 +45,7 @@ module Zaikio
     end
 
     def self.mocked_jwt_payload
-      @mocked_jwt_payload
+      instance_variable_defined?(:@mocked_jwt_payload) && @mocked_jwt_payload
     end
 
     def self.mocked_jwt_payload=(payload)

--- a/lib/zaikio/jwt_auth.rb
+++ b/lib/zaikio/jwt_auth.rb
@@ -67,8 +67,12 @@ module Zaikio
     end
 
     module ClassMethods
-      def authorize_by_jwt_subject_type(type = nil)
-        @authorize_by_jwt_subject_type ||= type
+      def authorize_by_jwt_subject_type(type = :_not_given_)
+        if type != :_not_given_
+          @authorize_by_jwt_subject_type = type
+        elsif instance_variable_defined?(:@authorize_by_jwt_subject_type)
+          @authorize_by_jwt_subject_type
+        end
       end
 
       def authorize_by_jwt_scopes(scopes = nil, options = {})

--- a/lib/zaikio/jwt_auth/directory_cache.rb
+++ b/lib/zaikio/jwt_auth/directory_cache.rb
@@ -56,20 +56,26 @@ module Zaikio
 
           data
         rescue Errno::ECONNREFUSED, Net::ReadTimeout, BadResponseError
-          Zaikio::JWTAuth.configuration.logger.info("Error updating DirectoryCache(#{directory_path}), enqueueing job to update")
+          Zaikio::JWTAuth.configuration.logger
+                         .info("Error updating DirectoryCache(#{directory_path}), enqueueing job to update")
           UpdateJob.set(wait: 10.seconds).perform_later(directory_path)
           nil
         end
 
         def fetch_from_directory(directory_path)
-          uri = URI("#{Zaikio::JWTAuth.configuration.host}/#{directory_path}")
-          http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = uri.scheme == "https"
-          response = http.request(Net::HTTP::Get.new(uri.request_uri))
+          response = make_http_request(directory_path)
+
           raise BadResponseError unless (200..299).cover?(response.code.to_i)
           raise BadResponseError unless response["content-type"].to_s.include?("application/json")
 
           Oj.load(response.body)
+        end
+
+        def make_http_request(directory_path)
+          uri = URI("#{Zaikio::JWTAuth.configuration.host}/#{directory_path}")
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = uri.scheme == "https"
+          http.request(Net::HTTP::Get.new(uri.request_uri))
         end
       end
     end

--- a/test/dummy/config/initializers/zaikio_jwt_auth.rb
+++ b/test/dummy/config/initializers/zaikio_jwt_auth.rb
@@ -1,5 +1,7 @@
-Zaikio::JWTAuth.configure do |config|
-  config.environment = :sandbox # or production
-  config.app_name = "test_app" # Your Zaikio App-Name
-  config.redis = Redis.new
+Rails.application.reloader.to_prepare do
+  Zaikio::JWTAuth.configure do |config|
+    config.environment = :sandbox # or production
+    config.app_name = "test_app" # Your Zaikio App-Name
+    config.redis = Redis.new
+  end
 end

--- a/test/zaikio/jwt_auth_test.rb
+++ b/test/zaikio/jwt_auth_test.rb
@@ -261,4 +261,18 @@ class ResourcesControllerTest < ActionDispatch::IntegrationTest # rubocop:disabl
     assert_response :forbidden
     assert_equal({ "errors" => ["unpermitted_scope"] }.to_json, response.body)
   end
+
+  test ".authorize_by_jwt_subject_type can be set multiple times and even cleared" do
+    controller = Class.new(ApplicationController) do
+      include Zaikio::JWTAuth
+    end
+
+    controller.authorize_by_jwt_subject_type "Organization"
+    controller.authorize_by_jwt_subject_type "Person"
+
+    assert_equal "Person", controller.authorize_by_jwt_subject_type
+
+    controller.authorize_by_jwt_subject_type nil
+    assert_nil controller.authorize_by_jwt_subject_type
+  end
 end

--- a/test/zaikio/jwt_auth_test.rb
+++ b/test/zaikio/jwt_auth_test.rb
@@ -275,4 +275,21 @@ class ResourcesControllerTest < ActionDispatch::IntegrationTest # rubocop:disabl
     controller.authorize_by_jwt_subject_type nil
     assert_nil controller.authorize_by_jwt_subject_type
   end
+
+  test ".authorize_by_jwt_subject_type is inherited by child classes" do
+    child = Class.new(ResourcesController)
+    assert_equal "Organization", child.authorize_by_jwt_subject_type
+
+    other = Class.new(OtherAppResourcesController)
+    assert_nil other.authorize_by_jwt_subject_type
+  end
+
+  test ".authorize_by_jwt_scopes is inherited by child classes" do
+    child = Class.new(ResourcesController)
+    assert_equal ResourcesController.authorize_by_jwt_scopes, child.authorize_by_jwt_scopes
+
+    other = Class.new(OtherAppResourcesController)
+    assert_equal [{ app_name: "directory", scopes: :organization }],
+                 other.authorize_by_jwt_scopes
+  end
 end


### PR DESCRIPTION
This behaves similarly to other Rails mechanisms, when inheriting you get the behaviour of the parent class, this also required the ability to change the value after it was set once, and potentially setting it back to `nil`.

I've also fixed a few Rubocop complaints and Ruby warnings while I was here.

Closes https://github.com/zaikio/zaikio-jwt_auth/issues/262