### PR TITLE
Switch `config.redis` to `config.cache`, support `Rails.cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* **BREAKING** `config.redis` has been replaced with `config.cache`, replacing the
+  direct Redis dependency with an instance of a `ActiveSupport::Cache::Store`. If you
+  wish to keep using Redis, you should wrap it like so:
+
+```diff
+-config.redis = Redis.new
++config.cache = ActiveSupport::Cache::RedisCacheStore.new
+```
+
+  Alternatively, you can also use `Rails.cache` to use a different backend:
+
+```diff
+-config.redis = Redis.new
++config.cache = Rails.cache
+```
+
 ## [1.0.2] - 2022-04-21
 
 * After setting `authorize_by_jwt_subject_type` and `authorize_by_jwt_scopes` in a

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ $ gem install zaikio-jwt_auth
 Zaikio::JWTAuth.configure do |config|
   config.environment = :sandbox # or production
   config.app_name = "test_app" # Your Zaikio App-Name
-  config.redis = Redis.new
+
+  # Enable caching Hub API responses for e.g. revoked tokens
+  config.cache = Rails.cache
 end
 ```
 
@@ -182,6 +184,13 @@ rescue JWT::DecodeError, JWT::ExpiredSignature
   [401, {}, ["Unauthorized"]]
 end
 ```
+
+### Using a different cache backend
+
+This client supports any implementation of
+[`ActiveSupport::Cache::Store`](https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html),
+but you can also write your own client that supports these methods: `#read(key)`,
+`#write(key, value)`, `#delete(key)`
 
 ## Contributing
 

--- a/lib/zaikio/jwt_auth/configuration.rb
+++ b/lib/zaikio/jwt_auth/configuration.rb
@@ -11,7 +11,7 @@ module Zaikio
         production: "https://hub.zaikio.com"
       }.freeze
 
-      attr_accessor :app_name, :redis, :host
+      attr_accessor :app_name, :cache, :host
       attr_reader :environment
       attr_writer :logger, :revoked_token_ids, :keys
 

--- a/lib/zaikio/jwt_auth/directory_cache.rb
+++ b/lib/zaikio/jwt_auth/directory_cache.rb
@@ -16,7 +16,7 @@ module Zaikio
 
       class << self
         def fetch(directory_path, options = {})
-          cache = Zaikio::JWTAuth.configuration.redis.get("zaikio::jwt_auth::#{directory_path}")
+          cache = Zaikio::JWTAuth.configuration.cache.read("zaikio::jwt_auth::#{directory_path}")
 
           json = Oj.load(cache) if cache
 
@@ -31,14 +31,14 @@ module Zaikio
         def update(directory_path, options = {})
           data = fetch(directory_path, options)
           data = yield(data)
-          Zaikio::JWTAuth.configuration.redis.set("zaikio::jwt_auth::#{directory_path}", {
+          Zaikio::JWTAuth.configuration.cache.write("zaikio::jwt_auth::#{directory_path}", {
             fetched_at: Time.now.to_i,
             data: data
           }.to_json)
         end
 
         def reset(directory_path)
-          Zaikio::JWTAuth.configuration.redis.del("zaikio::jwt_auth::#{directory_path}")
+          Zaikio::JWTAuth.configuration.cache.delete("zaikio::jwt_auth::#{directory_path}")
         end
 
         private
@@ -49,7 +49,7 @@ module Zaikio
 
         def reload_or_enqueue(directory_path)
           data = fetch_from_directory(directory_path)
-          Zaikio::JWTAuth.configuration.redis.set("zaikio::jwt_auth::#{directory_path}", {
+          Zaikio::JWTAuth.configuration.cache.write("zaikio::jwt_auth::#{directory_path}", {
             fetched_at: Time.now.to_i,
             data: data
           }.to_json)

--- a/test/dummy/config/initializers/zaikio_jwt_auth.rb
+++ b/test/dummy/config/initializers/zaikio_jwt_auth.rb
@@ -2,6 +2,6 @@ Rails.application.reloader.to_prepare do
   Zaikio::JWTAuth.configure do |config|
     config.environment = :sandbox # or production
     config.app_name = "test_app" # Your Zaikio App-Name
-    config.redis = Redis.new
+    config.cache = Rails.cache
   end
 end

--- a/test/jobs/zaikio/jwt_auth/revoke_access_token_job_test.rb
+++ b/test/jobs/zaikio/jwt_auth/revoke_access_token_job_test.rb
@@ -5,7 +5,7 @@ class Zaikio::JWTAuth::RevokeAccessTokenJobTest < ActiveSupport::TestCase
     Zaikio::JWTAuth.configure do |config|
       config.environment = :test
       config.app_name = "test_app"
-      config.redis = Redis.new
+      config.cache = ActiveSupport::Cache::RedisCacheStore.new
     end
 
     stub_requests

--- a/test/zaikio/directory_cache_test.rb
+++ b/test/zaikio/directory_cache_test.rb
@@ -5,6 +5,7 @@ module Zaikio::JWTAuth
     def setup
       Zaikio::JWTAuth.configure do |config|
         config.environment = :test
+        config.cache = ActiveSupport::Cache::RedisCacheStore.new
       end
     end
 

--- a/test/zaikio/jwt_auth_test.rb
+++ b/test/zaikio/jwt_auth_test.rb
@@ -5,7 +5,7 @@ class Zaikio::JWTAuth::Test < ActiveSupport::TestCase
     Zaikio::JWTAuth.configure do |config|
       config.environment = :test
       config.app_name = "test_app"
-      config.redis = Redis.new
+      config.cache = ActiveSupport::Cache::RedisCacheStore.new
     end
 
     stub_requests
@@ -29,13 +29,13 @@ class Zaikio::JWTAuth::Test < ActiveSupport::TestCase
     Zaikio::JWTAuth.configure do |config|
       config.environment = :test
       config.app_name = "test_app"
-      config.redis = Redis.new
+      config.cache = ActiveSupport::Cache::RedisCacheStore.new
     end
 
     assert_equal :test,                   Zaikio::JWTAuth.configuration.environment
     assert_equal "test_app",              Zaikio::JWTAuth.configuration.app_name
     assert_match "hub.zaikio.test", Zaikio::JWTAuth.configuration.host
-    assert_not_nil Zaikio::JWTAuth.configuration.redis
+    assert_not_nil Zaikio::JWTAuth.configuration.cache
   end
 
   test "revoked_jwt?" do
@@ -116,7 +116,7 @@ class ResourcesControllerTest < ActionDispatch::IntegrationTest # rubocop:disabl
     Zaikio::JWTAuth.configure do |config|
       config.environment = :test
       config.app_name = "test_app"
-      config.redis = Redis.new
+      config.cache = ActiveSupport::Cache::RedisCacheStore.new
     end
 
     stub_requests

--- a/test/zaikio/test_helper_test.rb
+++ b/test/zaikio/test_helper_test.rb
@@ -41,7 +41,7 @@ class TestHelperTest < ActionDispatch::IntegrationTest
     Zaikio::JWTAuth.configure do |config|
       config.environment = :test
       config.app_name = "test_app"
-      config.redis = Redis.new
+      config.cache = ActiveSupport::Cache::RedisCacheStore.new
     end
 
     Rails.application.routes.draw do


### PR DESCRIPTION
This change allows the user to use the built-in Rails cache configuration, rather than explicitly configuring a separate Redis. This might be desirable for:

  * Pooling connections
  * Using compression or other advanced features
  * Using a different backend (e.g. memcache, mongo) or even the null backend during CI