### PR TITLE
Support custom options for JWT check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added support for `jwt_options` in controller to customize JWT options
+
 ## [2.0.0] - 2022-04-29
 
 * **BREAKING** `config.redis` has been replaced with `config.cache`, replacing the

--- a/README.md
+++ b/README.md
@@ -192,6 +192,18 @@ This client supports any implementation of
 but you can also write your own client that supports these methods: `#read(key)`,
 `#write(key, value)`, `#delete(key)`
 
+### Pass custom options to JWT auth
+
+In some cases you want to add custom options to the JWT check. For example you want to allow expired JWTs when revoking access tokens.
+
+```rb
+class API::RevokedAccessTokensController < API::ApplicationController
+  def jwt_options
+    { verify_expiration: false }
+  end
+end
+```
+
 ## Contributing
 
 **Make sure you have the dummy app running locally to validate your changes.**


### PR DESCRIPTION
This is needed for Zaikio Hub to allow revocation of expired access tokens that still have a valid refresh token