### PR TITLE
Use an actual UUID in the mock JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2022-09-06
+
+* Mocked JWTs now contain actual random UUIDs instead of a fixed string
+
 ## [2.1.0] - 2022-08-02
 
 * Added support for `jwt_options` in controller to customize JWT options

--- a/lib/zaikio/jwt_auth/test_helper.rb
+++ b/lib/zaikio/jwt_auth/test_helper.rb
@@ -11,7 +11,7 @@ module Zaikio
           iss: "ZAI",
           sub: nil,
           aud: %w[test_app],
-          jti: "unique-access-token-id",
+          jti: SecureRandom.uuid,
           nbf: Time.now.to_i,
           exp: 1.hour.from_now.to_i,
           jku: "http://hub.zaikio.test/api/v1/jwt_public_keys.json",

--- a/lib/zaikio/jwt_auth/version.rb
+++ b/lib/zaikio/jwt_auth/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module JWTAuth
-    VERSION = "2.1.0".freeze
+    VERSION = "2.1.1".freeze
   end
 end


### PR DESCRIPTION
Previously a fixed string was used but in cases where the client actually cares about the data inside the JWT, say for auditing purposes, more realistic data is needed. I also believe it is important that mock data is as close to real life as possible, so this should be a UUID.

I also couldn't come up with any adverse effects this might have over the static string.