### PR TITLE
Add middleware for rack attack throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added rack Middleware for rack-attack throttling
+
 ## [2.1.1] - 2022-09-06
 
 * Mocked JWTs now contain actual random UUIDs instead of a fixed string

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-jwt_auth (2.1.0)
+    zaikio-jwt_auth (2.1.1)
       activejob
       jwt (>= 2.2.1)
       oj (>= 3.0.0)

--- a/lib/zaikio/jwt_auth.rb
+++ b/lib/zaikio/jwt_auth.rb
@@ -6,6 +6,7 @@ require "zaikio/jwt_auth/configuration"
 require "zaikio/jwt_auth/directory_cache"
 require "zaikio/jwt_auth/jwk"
 require "zaikio/jwt_auth/token_data"
+require "zaikio/jwt_auth/rack_middleware"
 require "zaikio/jwt_auth/engine"
 require "zaikio/jwt_auth/test_helper"
 

--- a/lib/zaikio/jwt_auth/rack_middleware.rb
+++ b/lib/zaikio/jwt_auth/rack_middleware.rb
@@ -1,0 +1,27 @@
+module Zaikio
+  module JWTAuth
+    class RackMiddleware
+      AUDIENCE = "zaikio.jwt.audience".freeze
+      SUBJECT  = "zaikio.jwt.subject".freeze
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        token_data = begin
+          Zaikio::JWTAuth.extract(env["HTTP_AUTHORIZATION"])
+        rescue JWT::ExpiredSignature, JWT::DecodeError
+          nil
+        end
+
+        if token_data
+          env[AUDIENCE] = token_data.audience || :personal_token
+          env[SUBJECT] = token_data.subject
+        end
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/zaikio/jwt_auth/token_data.rb
+++ b/lib/zaikio/jwt_auth/token_data.rb
@@ -95,6 +95,10 @@ module Zaikio
         subject_match[5]
       end
 
+      def subject
+        "#{subject_type}/#{subject_id}"
+      end
+
       def on_behalf_of_id
         subject_match[3]
       end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -28,3 +28,4 @@ module Dummy
   end
 end
 
+Dummy::Application.config.middleware.insert_after ActionDispatch::ContentSecurityPolicy::Middleware, Zaikio::JWTAuth::RackMiddleware

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,7 @@ Rails::TestUnitReporter.executable = "bin/test"
 
 require_relative "../app/jobs/zaikio/jwt_auth/revoke_access_token_job"
 
-class ActiveSupport::TestCase
+class ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
   include Zaikio::JWTAuth::TestHelper
 
   def dummy_private_key

--- a/test/zaikio/rack_middleware_test.rb
+++ b/test/zaikio/rack_middleware_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class MiddlewareResourcesController < ApplicationController
+  include Zaikio::JWTAuth
+
+  before_action :authenticate_by_jwt, if: -> { params["skip"].blank? }
+  authorize_by_jwt_scopes :resources, if: -> { params["skip"].blank? }
+
+  def index
+    if request.env["zaikio.jwt.subject"]
+      render plain: [request.env["zaikio.jwt.audience"], request.env["zaikio.jwt.subject"]].compact.join(", ")
+    else
+      render plain: "other_auth"
+    end
+  end
+end
+
+class Zaikio::JWTAuth::RackMiddlewareTest < ActionDispatch::IntegrationTest
+  def setup
+    Zaikio::JWTAuth.configure do |config|
+      config.environment = :test
+      config.app_name = "test_app"
+      config.cache = ActiveSupport::Cache::RedisCacheStore.new
+    end
+
+    stub_requests
+
+    Zaikio::JWTAuth::DirectoryCache.reset("api/v1/revoked_access_tokens.json")
+
+    Rails.application.routes.draw do
+      resources :middleware_resources, only: :index
+    end
+  end
+
+  test "adds env variables through middleware" do
+    token = generate_token(exp: 2.hours.from_now.to_i)
+    get "/middleware_resources", headers: { "Authorization" => "Bearer #{token}" }
+    assert_response :success
+    assert_equal "directory, Organization/123", response.body
+  end
+
+  test "works also if other auth header is used" do
+    get "/middleware_resources", headers: { "Authorization" => "Bearer #{Base64.encode64('123:other_auth')}" },
+                                 params: { skip: "1" }
+    assert_response :success
+    assert_equal "other_auth", response.body
+  end
+
+  test "works also if other auth header is not set" do
+    get "/middleware_resources", params: { skip: "1" }
+    assert_response :success
+    assert_equal "other_auth", response.body
+  end
+end


### PR DESCRIPTION
Extracted from Zaikio Procurement.

I did some smaller changes to make sure also other Authorization methods will work with this middleware (e.g. we use different methods Keyline).