### PR TITLE
Fix `NoMethodError` in implementation of `DirectoryCache.fetch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Fix `NoMethodError: undefined method '[]' for nil` when Directory cache is unavailable
+* Ensure callers handle `DirectoryCache.fetch` returning nil
 
 ## [2.2.0] - 2022-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `NoMethodError: undefined method '[]' for nil` when Directory cache is unavailable
+
 ## [2.2.0] - 2022-09-28
 
 * Added rack Middleware for rack-attack throttling

--- a/lib/zaikio/jwt_auth.rb
+++ b/lib/zaikio/jwt_auth.rb
@@ -34,10 +34,14 @@ module Zaikio
     def self.revoked_token_ids
       return [] if mocked_jwt_payload
 
-      configuration.revoked_token_ids || DirectoryCache.fetch(
+      return configuration.revoked_token_ids if configuration.revoked_token_ids
+
+      result = DirectoryCache.fetch(
         "api/v1/revoked_access_tokens.json",
         expires_after: 60.minutes
-      )["revoked_token_ids"]
+      ) || {}
+
+      result.fetch("revoked_token_ids", [])
     end
 
     def self.included(base)

--- a/lib/zaikio/jwt_auth/directory_cache.rb
+++ b/lib/zaikio/jwt_auth/directory_cache.rb
@@ -18,14 +18,13 @@ module Zaikio
         def fetch(directory_path, options = {})
           cache = Zaikio::JWTAuth.configuration.cache.read("zaikio::jwt_auth::#{directory_path}")
 
-          json = Oj.load(cache) if cache
+          return reload_or_enqueue(directory_path) unless cache
 
-          if !cache || options[:invalidate] || cache_expired?(json, options[:expires_after])
-            new_values = reload_or_enqueue(directory_path)
-            return new_values || json["data"]
-          end
+          json = Oj.load(cache)
 
-          json["data"]
+          if options[:invalidate] || cache_expired?(json, options[:expires_after])
+            reload_or_enqueue(directory_path)
+          end || json["data"]
         end
 
         def update(directory_path, options = {})

--- a/lib/zaikio/jwt_auth/directory_cache.rb
+++ b/lib/zaikio/jwt_auth/directory_cache.rb
@@ -15,6 +15,19 @@ module Zaikio
       BadResponseError = Class.new(StandardError)
 
       class << self
+        # Retrieve some data from the Hub, reachable at `directory_path`. Attempts to
+        # retrieve data from a cache first (usually Redis, if configured). Caching can be
+        # skipped by setting an `:invalidate` option, or if the cached data is stale it
+        # will be refetched from the Hub anyway. Please note that this method can return
+        # `nil` if there is no cache available and the Hub is giving error responses or
+        # failures.
+        #
+        # @example Fetching revoked access token information
+        #
+        #   DirectoryCache.fetch("api/v1/revoked_access_tokens.json")
+        #
+        # @returns Hash (in the happy path)
+        # @returns nil (if the cache is unavailable and the API is down)
         def fetch(directory_path, options = {})
           cache = Zaikio::JWTAuth.configuration.cache.read("zaikio::jwt_auth::#{directory_path}")
 

--- a/lib/zaikio/jwt_auth/jwk.rb
+++ b/lib/zaikio/jwt_auth/jwk.rb
@@ -30,7 +30,7 @@ module Zaikio
         def keys
           return Zaikio::JWTAuth.configuration.keys if Zaikio::JWTAuth.configuration.keys
 
-          fetch_from_cache["keys"]
+          fetch_from_cache.fetch("keys")
         end
 
         def fetch_from_cache(options = {})

--- a/test/zaikio/directory_cache_test.rb
+++ b/test/zaikio/directory_cache_test.rb
@@ -61,5 +61,14 @@ module Zaikio::JWTAuth
         DirectoryCache.fetch("foo.json")
       )
     end
+
+    test "if the cache AND API are unavailable, returns nil" do
+      Zaikio::JWTAuth.configuration.cache.delete("zaikio::jwt_auth::foo.json")
+
+      stub_request(:get, "http://hub.zaikio.test/foo.json")
+        .to_return(status: 500)
+
+      assert_nil DirectoryCache.fetch("foo.json")
+    end
   end
 end


### PR DESCRIPTION
The previous code said:

```ruby
json = Oj.load(cache) if cache
```

The problem with this is that `json` is `nil` if the cache fails (e.g. when Redis is down). However, further down in the method are several places which are actually expecting the JSON to be a hash.

I've rewritten the method to return early if this is the cache is unavailable, I hope this can fix the problem.