### PR TITLE
Handle errors when DirectoryCache is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Handle errors when fetching the directory cache and fallback to API
+
 ## [2.6.0] - 2023-06-05
 
 * Support on behalf access tokens when `authorize_by_jwt_subject_type "Person"`

--- a/lib/zaikio/jwt_auth/directory_cache.rb
+++ b/lib/zaikio/jwt_auth/directory_cache.rb
@@ -29,7 +29,14 @@ module Zaikio
         # @returns Hash (in the happy path)
         # @returns nil (if the cache is unavailable and the API is down)
         def fetch(directory_path, options = {})
-          cache = Zaikio::JWTAuth.configuration.cache.read("zaikio::jwt_auth::#{directory_path}")
+          cache = begin
+            Zaikio::JWTAuth.configuration.cache.read("zaikio::jwt_auth::#{directory_path}")
+          rescue StandardError => e
+            Zaikio::JWTAuth.configuration.logger
+                           .warn("Error reading DirectoryCache(#{directory_path}) from Cache, falling "\
+                                 "back to API: #{e.inspect}")
+            nil
+          end
 
           return reload_or_enqueue(directory_path) unless cache
 


### PR DESCRIPTION
To better handle errors like https://appsignal.com/zaikio/sites/5dfb6c05026444097f5f0f3d/exceptions/incidents/2609